### PR TITLE
Disables 'click' and 'scroll' event propagation

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "leaflet-control-angular",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Allows for the use of AngularJS in custom leaflet controls.",
   "dependencies": {
     "angular": "~1.5.0",

--- a/bower.json
+++ b/bower.json
@@ -3,8 +3,8 @@
   "version": "0.1.3",
   "description": "Allows for the use of AngularJS in custom leaflet controls.",
   "dependencies": {
-    "angular": "^1.5",
-    "leaflet": "^0.7.7"
+    "angular": "~1.5.0",
+    "leaflet": "~0.7.7"
   },
   "main": "src/L.Control.Angular.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
       "en": "leaflet-control-angular"
    },
    "language": "JavaScript",
-   "version": "0.1.3",
+   "version": "0.1.4",
    "description": "Allows for the use of AngularJS in custom leaflet controls.",
    "repository": {
       "type": "git",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
    ],
    "main": "src/L.Control.Angular.js",
    "dependencies": {
-      "leaflet": "^0.7.7",
-      "angular": "^1.5.0"
+      "angular": "~1.5.0",
+      "leaflet": "~0.7.7"
    },
    "repository": {
       "type": "git",

--- a/src/L.Control.Angular.js
+++ b/src/L.Control.Angular.js
@@ -8,13 +8,16 @@
      onAdd: function onAdd (map) {
          var that = this;
          this._container = L.DomUtil.create('div', 'angular-control-leaflet');
-         
-         L.DomEvent
-            .on(this._container, 'dblclick', L.DomEvent.stop)
-            .on(this._container, 'click', L.DomEvent.stop);
+
+         if (!L.Browser.touch) {
+             L.DomEvent
+               .disableClickPropagation(this._container)
+               .disableScrollPropagation(this._container);
+         } else {
+             L.DomEvent.disableClickPropagation(this._container);
+         }
          
          angular.element(document).ready(function() {
-             
              var $injector = angular.element(document).injector();
 
              if (!$injector) {
@@ -59,10 +62,6 @@
         if(this._scope){
             this._scope.$destroy();
         }
-        
-        L.DomEvent
-            .off(this._container, 'dblclick', L.DomEvent.stop)
-            .off(this._container, 'click', L.DomEvent.stop);
      }
  });
 


### PR DESCRIPTION
Hello @grantHarris, hope you are doing great.

This PR addresses an issue where event handlers attached to the page document object would not be fired when clicking anywhere on the container element of an angular leaflet control.

In addition to this minor fix I have disabled the propagation of scroll events to prevent zooming on the map when scrolling over an angular leaflet control.

Changes are compatible with [leaflet 0.7.7](https://github.com/Leaflet/Leaflet/blob/v0.7.7/src/dom/DomEvent.js#L109)

Cheers!